### PR TITLE
add clickhouse_secure to the spicepod.yaml

### DIFF
--- a/clickhouse/spicepod.yaml
+++ b/clickhouse/spicepod.yaml
@@ -10,6 +10,7 @@ datasets:
       clickhouse_tcp_port: [Port]
       clickhouse_user: [Username]
       clickhouse_pass: [Password]
+      clickhouse_secure: [true/false] # Default to true.  Set to false if not connecting over SSL
     acceleration:
       enabled: true
       refresh_mode: full


### PR DESCRIPTION
If the user of the quickstart is just grabbing a clickhouse container for a quick test, they'll get an SSL error because we default this parameter to true.