### PR TITLE
Use duckdb instead of sqlite for acceleration index quickstart

### DIFF
--- a/acceleration/indexes/README.md
+++ b/acceleration/indexes/README.md
@@ -19,22 +19,23 @@ wget https://public-data.spiceai.org/large_eth_traces.parquet
 **Step 3.** Add the spicepod with indexes configured
 
 Add the following to your `spicepod.yaml`. Be sure to replace `path/to/large_eth_traces.parquet` with the absolute path to the downloaded dataset.
+
 ```yaml
 datasets:
-- from: file://path/to/large_eth_traces.parquet
-  name: traces
-  acceleration:
-    enabled: true
-    engine: sqlite
-    mode: file
-    indexes:
-      trace_id: enabled
-- from: file://path/to/large_eth_traces.parquet
-  name: traces_no_index
-  acceleration:
-    enabled: true
-    engine: sqlite
-    mode: file
+  - from: file://path/to/large_eth_traces.parquet
+    name: traces
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
+      indexes:
+        trace_id: enabled
+  - from: file://path/to/large_eth_traces.parquet
+    name: traces_no_index
+    acceleration:
+      enabled: true
+      engine: duckdb
+      mode: file
 ```
 
 **Step 4.** Start Spice


### PR DESCRIPTION
## 🗣 Description

SQLite acclerator only support decimal for up to 16 precision, while the dataset used in quickstart have decimal columns with greater precision. Use duckdb instead for this quickstart

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
