### PR TITLE
Update spicepod for mysql local quickstart

### DIFF
--- a/mysql/spicepod.yaml
+++ b/mysql/spicepod.yaml
@@ -10,6 +10,7 @@ datasets:
       mysql_tcp_port: [Port]
       mysql_user: [User]
       mysql_pass: ${env:MYSQL_PASS}
+      mysql_sslmode: disabled
     acceleration:
       enabled: true
       refresh_mode: full


### PR DESCRIPTION
## 🗣 Description

Quickstart uses local mysql, which requires SSL to be disabled