### PR TITLE
Update `show stables` output, remove query_history table

### DIFF
--- a/catalogs/spiceai/README.md
+++ b/catalogs/spiceai/README.md
@@ -82,7 +82,6 @@ sql> show tables
 | spiceai       | goerli       | wallet_lst_balances                                            | BASE TABLE |
 | spice         | runtime      | task_history                                                   | BASE TABLE |
 | spice         | runtime      | metrics                                                        | BASE TABLE |
-| spice         | runtime      | query_history                                                  | BASE TABLE |
 +---------------+--------------+----------------------------------------------------------------+------------+
 
 Time: 0.007676958 seconds. 249 rows.
@@ -115,7 +114,6 @@ sql> show tables
 | spiceai       | tpch         | supplier      | BASE TABLE |
 | spice         | runtime      | task_history  | BASE TABLE |
 | spice         | runtime      | metrics       | BASE TABLE |
-| spice         | runtime      | query_history | BASE TABLE |
 +---------------+--------------+---------------+------------+
 
 Time: 0.001866958 seconds. 9 rows.

--- a/databricks/README.md
+++ b/databricks/README.md
@@ -75,7 +75,7 @@ Spice can read data straight from a Databricks instance. This guide will create 
     | table_catalog | table_schema | table_name    | table_type |
     +---------------+--------------+---------------+------------+
     | spice         | public       | my_table      | BASE TABLE |
-    | spice         | runtime      | query_history | BASE TABLE |
+    | spice         | runtime      | task_history  | BASE TABLE |
     | spice         | runtime      | metrics       | BASE TABLE |
     +---------------+--------------+---------------+------------+
 

--- a/postgres/connector/README.md
+++ b/postgres/connector/README.md
@@ -177,7 +177,6 @@ sql> show tables;
 +---------------+--------------+---------------+------------+
 | spice         | public       | sample_data   | BASE TABLE |
 | spice         | runtime      | task_history  | BASE TABLE |
-| spice         | runtime      | query_history | BASE TABLE |
 | spice         | runtime      | metrics       | BASE TABLE |
 +---------------+--------------+---------------+------------+
 

--- a/s3/README.md
+++ b/s3/README.md
@@ -99,7 +99,8 @@ sql> show tables;
 | table_catalog | table_schema | table_name    | table_type |
 +---------------+--------------+---------------+------------+
 | spice         | public       | taxi_trips    | BASE TABLE |
-| spice         | runtime      | query_history | BASE TABLE |
+| spice         | runtime      | task_history  | BASE TABLE |
+| spice         | runtime      | metrics       | BASE TABLE |
 +---------------+--------------+---------------+------------+
 
 Time: 0.010070708 seconds. 2 rows.

--- a/snowflake/README.md
+++ b/snowflake/README.md
@@ -99,7 +99,8 @@ sql> show tables;
 | table_catalog | table_schema | table_name    | table_type |
 +---------------+--------------+---------------+------------+
 | spice         | public       | lineitem      | BASE TABLE |
-| spice         | runtime      | query_history | BASE TABLE |
+| spice         | runtime      | task_history  | BASE TABLE |
+| spice         | runtime      | metrics       | BASE TABLE |
 +---------------+--------------+---------------+------------+
 
 Time: 0.032075708 seconds. 2 rows.


### PR DESCRIPTION
Removed deprecated `query_history`