### PR TITLE
Rename spiceai data connector to spice.ai 

### DIFF
--- a/catalogs/spiceai/README.md
+++ b/catalogs/spiceai/README.md
@@ -35,7 +35,7 @@ Add the following configuration to your `spicepod.yaml`:
 
 ```yaml
 catalogs:
-  - name: spiceai
+  - name: spice.ai
     from: spiceai
 ```
 


### PR DESCRIPTION
## 🗣 Description

Update docs according to: [Rename spiceai data connector to spice.ai](https://github.com/spiceai/spiceai/pull/2680)

~Currently Draft to merge after `0.18.3-beta` release~
